### PR TITLE
fix: number parsing causing NaN fees

### DIFF
--- a/src/components/PoolForm/PoolForm.tsx
+++ b/src/components/PoolForm/PoolForm.tsx
@@ -166,10 +166,7 @@ const PoolForm: FC<Props> = ({
         <PositionItem>
           <div>Total fees earned</div>
           <div>
-            {Number(formatUnits(feesEarned, decimals)) > 0
-              ? formatUnits(feesEarned, decimals)
-              : "0.0000"}{" "}
-            {symbol}
+            {formatUnits(feesEarned, decimals)} {symbol}
           </div>
         </PositionItem>
       </Position>


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

format units return a formatted number string, like "1,000". This fails to parse as a number because of the comma.

before: 
![image](https://user-images.githubusercontent.com/4429761/156578833-6d522cb8-4f55-46b3-8ae8-161660de833c.png)

after: 
![image](https://user-images.githubusercontent.com/4429761/156579136-eb0681a0-a04b-4dc3-ae28-cee70a3ea2bd.png)

