### PR TITLE
fix: pool add liquidity approval checks amount to be added

### DIFF
--- a/src/components/CoinSelection/CoinSelection.styles.ts
+++ b/src/components/CoinSelection/CoinSelection.styles.ts
@@ -11,7 +11,9 @@ export const Wrapper = styled.div`
   flex-direction: column;
 `;
 // User agents wars, so have to check for chrome too
-const isSafari = navigator.userAgent.search("Safari") >= 0 && navigator.userAgent.search("Chrome") < 0
+const isSafari =
+  navigator.userAgent.search("Safari") >= 0 &&
+  navigator.userAgent.search("Chrome") < 0;
 export const RoundBox = styled(UnstyledBox)`
   --color: var(--color-white);
   --outline-color: var(--color-primary);
@@ -75,7 +77,8 @@ export const Menu = styled.ul<MenuProps>`
   right: 0;
   padding-top: 10px;
   transform: translateY(50%);
-  box-shadow: ${({ isOpen }) => (isOpen ? `0px 160px 8px 8px hsla(${COLORS.gray[500]} / 0.2)` : "none")};
+  box-shadow: ${({ isOpen }) =>
+    isOpen ? `0px 160px 8px 8px hsla(${COLORS.gray[500]} / 0.2)` : "none"};
   list-style: none;
   display: flex;
   flex-direction: column;

--- a/src/hooks/useERC20.ts
+++ b/src/hooks/useERC20.ts
@@ -11,7 +11,19 @@ type ApproveArgs = {
 type Approve = (
   args: ApproveArgs
 ) => Promise<ethers.ContractTransaction | undefined>;
-export function useERC20(tokenAddress: string): { approve: Approve } {
+
+type AllowanceArgs = {
+  account: string;
+  spender: string;
+  provider: ethers.Signer | ethers.providers.Provider;
+};
+
+type Allowance = (args: AllowanceArgs) => Promise<ethers.BigNumber>;
+
+export function useERC20(tokenAddress: string): {
+  approve: Approve;
+  allowance: Allowance;
+} {
   const approve = useCallback(
     async ({ spender, amount, signer }: ApproveArgs) => {
       if (!signer) {
@@ -24,5 +36,13 @@ export function useERC20(tokenAddress: string): { approve: Approve } {
     [tokenAddress]
   );
 
-  return { approve };
+  const allowance = useCallback(
+    async ({ spender, account, provider }: AllowanceArgs) => {
+      const token = clients.erc20.connect(tokenAddress, provider);
+      return token.allowance(account, spender);
+    },
+    [tokenAddress]
+  );
+
+  return { approve, allowance };
 }


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

The pool tab had some assumptions with approvals, these were made for expedience, but it was assumed we always allowed infinite, and we always assumed user was clicking to deposit max liquidity. 

This change makes it so we check allowance againts the amount to be added in the input  box.  Allowance queries have been separated from the check to prevent spamming the network while user is entering numbers. 