### PR TITLE
feat: add protection against sending to dead addresses

### DIFF
--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -505,7 +505,7 @@ export function useSendOptimism() {
         fees,
       };
     }
-  }, [amount, fees, token, isConnected, optimismBridge, signer]);
+  }, [amount, fees, token, isConnected, optimismBridge, signer, fromChain]);
 
   const approve = useCallback(() => {
     if (!signer) return;
@@ -639,7 +639,7 @@ export function useSendArbitrum() {
         fees,
       };
     }
-  }, [bridge, amount, fees, token, isConnected, toAddress]);
+  }, [bridge, amount, fees, token, isConnected, toAddress, fromChain]);
 
   const approve = useCallback(async () => {
     if (!bridge) return;
@@ -788,7 +788,7 @@ export function useSendBoba() {
         fees,
       };
     }
-  }, [amount, fees, token, isConnected, bobaBridge, signer]);
+  }, [amount, fees, token, isConnected, bobaBridge, signer, fromChain]);
 
   const approve = useCallback(() => {
     if (!signer) return;

--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -641,7 +641,7 @@ export function useSendArbitrum() {
     }
   }, [bridge, amount, fees, token, isConnected, toAddress, fromChain]);
 
-  const approve = useCallback(async () => {
+  const approve = useCallback(() => {
     if (!bridge) return;
     return bridge.approveToken(token, MAX_APPROVAL_AMOUNT);
   }, [bridge, token]);

--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -489,7 +489,7 @@ export function useSendOptimism() {
 
   const send = useCallback(async () => {
     if (!isConnected || !signer) return {};
-    if (!await validateContractAndChain(await optimismBridge.getL1BridgeAddress(await signer.getChainId()), fromChain, signer)) {
+    if (!await validateContractAndChain(bridgeAddress, fromChain, signer)) {
       return {};
     }
     if (token === ethers.constants.AddressZero) {
@@ -505,7 +505,7 @@ export function useSendOptimism() {
         fees,
       };
     }
-  }, [amount, fees, token, isConnected, optimismBridge, signer, fromChain]);
+  }, [amount, fees, token, isConnected, optimismBridge, signer, fromChain, bridgeAddress]);
 
   const approve = useCallback(() => {
     if (!signer) return;
@@ -772,7 +772,7 @@ export function useSendBoba() {
   const send = useCallback(async () => {
     if (!isConnected || !signer) return {};
 
-    if (!await validateContractAndChain(await bobaBridge.getL1BridgeAddress(await signer.getChainId(), PROVIDERS[fromChain]()), fromChain, signer)) {
+    if (!await validateContractAndChain(bridgeAddress, fromChain, signer)) {
       return {};
     }
     if (token === ethers.constants.AddressZero) {
@@ -788,7 +788,7 @@ export function useSendBoba() {
         fees,
       };
     }
-  }, [amount, fees, token, isConnected, bobaBridge, signer, fromChain]);
+  }, [amount, fees, token, isConnected, bobaBridge, signer, fromChain, bridgeAddress]);
 
   const approve = useCallback(() => {
     if (!signer) return;

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -1,4 +1,5 @@
-import { ethers } from "ethers";
+import { ethers, Signer } from "ethers";
+import { ChainId, PROVIDERS } from "./constants";
 
 export function isValidAddress(address: string) {
   return ethers.utils.isAddress(address);
@@ -6,4 +7,18 @@ export function isValidAddress(address: string) {
 
 export function getAddress(address: string) {
   return ethers.utils.getAddress(address);
+}
+
+export async function validateContractAndChain(contractAddress: string, expectedChainId: ChainId, signer: Signer): Promise<boolean> {
+    if (await signer.getChainId() !== expectedChainId) {
+      console.error("Signer chainId and intended chainId do not match");
+      return false;
+    }
+    const codeAtAddress = await PROVIDERS[expectedChainId]().getCode(contractAddress);
+    if (!codeAtAddress || codeAtAddress === "0x" || codeAtAddress === "0x0") {
+      console.error(`No code at ${contractAddress} on chainId ${expectedChainId}`);
+      return false;
+    }
+
+    return true;
 }


### PR DESCRIPTION
Note: this attempts to fix some issues with sends to nonexistent contracts.

In v2, we might want to build a custom signer, but that seemed pretty tricky to get right without breaking any existing code. For expedience, this adds additional checks before all send transactions.

It also adds the chainId to the additional options in the L2 -> L1 case. It can't add this parameter to others since those transactions are produced inside of clients.