### PR TITLE
fix: remove min height.

### DIFF
--- a/src/components/Dialog/Dialog.styles.tsx
+++ b/src/components/Dialog/Dialog.styles.tsx
@@ -13,7 +13,6 @@ export const Wrapper = styled(DialogContent)`
   width: min(440px, calc(100% - 20px));
   top: 10%;
   overflow: auto;
-  min-height: 60vh;
   max-height: 80vh;
   @media ${QUERIES.tabletAndUp} {
     top: 17%;


### PR DESCRIPTION
Remove min-height on the element. 
@chrismaree @Tommy1231232  let me know if this is acceptable on all screens.

Signed-off-by: Tulun <jaykiraly@gmail.com>