### PR TITLE
fix: allow query params to persist across tabs

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -53,7 +53,14 @@ const Header: React.FC = () => {
         <List>
           {LINKS.map(({ href, name }) => (
             <Item key={href} aria-selected={location.pathname === href}>
-              <Link to={href}>{name}</Link>
+              <Link
+                to={{
+                  pathname: href,
+                  search: location.search,
+                }}
+              >
+                {name}
+              </Link>
             </Item>
           ))}
         </List>
@@ -71,7 +78,14 @@ const Header: React.FC = () => {
                   key={href}
                   aria-selected={location.pathname === href}
                 >
-                  <MobileLink to={href}>{name}</MobileLink>
+                  <MobileLink
+                    to={{
+                      pathname: href,
+                      search: location.search,
+                    }}
+                  >
+                    {name}
+                  </MobileLink>
                 </MobileItem>
               ))}
               {MOBILE_ONLY_LINKS.map(({ href, name }) => (

--- a/src/components/InformationDialog/InformationDialog.tsx
+++ b/src/components/InformationDialog/InformationDialog.tsx
@@ -63,8 +63,8 @@ const InformationDialog: React.FC<Props> = ({ isOpen, onClose }) => {
             rel="noopener noreferrer"
           >
             here
-          </Link>
-          {" "}to learn more about Ethereum gas fees.
+          </Link>{" "}
+          to learn more about Ethereum gas fees.
         </Text>
       </Info>
 

--- a/src/components/SendAction/SendAction.styles.ts
+++ b/src/components/SendAction/SendAction.styles.ts
@@ -80,7 +80,7 @@ export const AmountToReceive = styled.div`
   span {
     font: inherit;
   }
-`
+`;
 
 export const L1Info = styled(Info)`
   justify-content: space-around;

--- a/src/components/SendAction/SendAction.tsx
+++ b/src/components/SendAction/SendAction.tsx
@@ -165,7 +165,7 @@ const SendAction: React.FC = () => {
           <>
             <InfoHeadlineContainer>
               <SlippageDisclaimer>
-              <ConfettiIcon />
+                <ConfettiIcon />
                 All transfers are slippage free!
               </SlippageDisclaimer>
               <FeesButton onClick={toggleInfoModal}>Fees info</FeesButton>

--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -315,15 +315,21 @@ export function useSendAcross() {
           ? tagAddress(data, referrer)
           : data;
 
-      if (!await validateContractAndChain(depositBox.address, currentlySelectedFromChain.chainId, signer)) {
+      if (
+        !(await validateContractAndChain(
+          depositBox.address,
+          currentlySelectedFromChain.chainId,
+          signer
+        ))
+      ) {
         return {};
       }
-      
+
       const tx = await signer.sendTransaction({
         data: taggedData,
         value,
         to: depositBox.address,
-        chainId: currentlySelectedFromChain.chainId
+        chainId: currentlySelectedFromChain.chainId,
       });
       return { tx, fees };
     } catch (e) {
@@ -489,7 +495,7 @@ export function useSendOptimism() {
 
   const send = useCallback(async () => {
     if (!isConnected || !signer) return {};
-    if (!await validateContractAndChain(bridgeAddress, fromChain, signer)) {
+    if (!(await validateContractAndChain(bridgeAddress, fromChain, signer))) {
       return {};
     }
     if (token === ethers.constants.AddressZero) {
@@ -505,7 +511,16 @@ export function useSendOptimism() {
         fees,
       };
     }
-  }, [amount, fees, token, isConnected, optimismBridge, signer, fromChain, bridgeAddress]);
+  }, [
+    amount,
+    fees,
+    token,
+    isConnected,
+    optimismBridge,
+    signer,
+    fromChain,
+    bridgeAddress,
+  ]);
 
   const approve = useCallback(() => {
     if (!signer) return;
@@ -620,7 +635,15 @@ export function useSendArbitrum() {
 
   const send = useCallback(async () => {
     if (!bridge || !isConnected) return {};
-    if (!await validateContractAndChain((await bridge.l1Bridge.getInbox()).address, fromChain, bridge.l1Bridge.l1Signer)) {
+    if (
+      !(await validateContractAndChain(
+        (
+          await bridge.l1Bridge.getInbox()
+        ).address,
+        fromChain,
+        bridge.l1Bridge.l1Signer
+      ))
+    ) {
       return {};
     }
     if (token === ethers.constants.AddressZero) {
@@ -772,7 +795,7 @@ export function useSendBoba() {
   const send = useCallback(async () => {
     if (!isConnected || !signer) return {};
 
-    if (!await validateContractAndChain(bridgeAddress, fromChain, signer)) {
+    if (!(await validateContractAndChain(bridgeAddress, fromChain, signer))) {
       return {};
     }
     if (token === ethers.constants.AddressZero) {
@@ -788,7 +811,16 @@ export function useSendBoba() {
         fees,
       };
     }
-  }, [amount, fees, token, isConnected, bobaBridge, signer, fromChain, bridgeAddress]);
+  }, [
+    amount,
+    fees,
+    token,
+    isConnected,
+    bobaBridge,
+    signer,
+    fromChain,
+    bridgeAddress,
+  ]);
 
   const approve = useCallback(() => {
     if (!signer) return;

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -9,16 +9,24 @@ export function getAddress(address: string) {
   return ethers.utils.getAddress(address);
 }
 
-export async function validateContractAndChain(contractAddress: string, expectedChainId: ChainId, signer: Signer): Promise<boolean> {
-    if (await signer.getChainId() !== expectedChainId) {
-      console.error("Signer chainId and intended chainId do not match");
-      return false;
-    }
-    const codeAtAddress = await PROVIDERS[expectedChainId]().getCode(contractAddress);
-    if (!codeAtAddress || codeAtAddress === "0x" || codeAtAddress === "0x0") {
-      console.error(`No code at ${contractAddress} on chainId ${expectedChainId}`);
-      return false;
-    }
+export async function validateContractAndChain(
+  contractAddress: string,
+  expectedChainId: ChainId,
+  signer: Signer
+): Promise<boolean> {
+  if ((await signer.getChainId()) !== expectedChainId) {
+    console.error("Signer chainId and intended chainId do not match");
+    return false;
+  }
+  const codeAtAddress = await PROVIDERS[expectedChainId]().getCode(
+    contractAddress
+  );
+  if (!codeAtAddress || codeAtAddress === "0x" || codeAtAddress === "0x0") {
+    console.error(
+      `No code at ${contractAddress} on chainId ${expectedChainId}`
+    );
+    return false;
+  }
 
-    return true;
+  return true;
 }


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

Most of these changes are due to linting.  The functional change here was to keep the query params in the url when switching tabs. This is accomplished by adding location.search to the links in the tabs.