### PR TITLE
fix: replace migration instructions url

### DIFF
--- a/src/components/PoolSelection/PoolSelection.tsx
+++ b/src/components/PoolSelection/PoolSelection.tsx
@@ -63,7 +63,7 @@ const PoolSelection: FC<Props> = ({ token, setToken, position }) => {
               If you have not migrated liquidity from Across v1 to Across v2,
               please follow{" "}
               <a
-                href="https://medium.com/across-protocol/lps-migrate-liquidity-from-v1-to-v2-screenshots-and-faqs-8616150b3396"
+                href="https://docs.across.to/v2/migrating-from-v1"
                 target="_blank"
                 rel="noreferrer"
               >


### PR DESCRIPTION
Signed-off-by: amateima <amatei@umaproject.org>

<img width="419" alt="Screenshot 2022-05-31 at 15 35 04" src="https://user-images.githubusercontent.com/89395931/171177506-3279fce0-960c-49e8-a629-9623fdfa9c8d.png">

instructions url has been changed to https://docs.across.to/v2/migrating-from-v1